### PR TITLE
FIX: persist

### DIFF
--- a/index.js
+++ b/index.js
@@ -369,7 +369,10 @@ function useAtomCreate(init) {
     }, [runEffects]);
     (0, react_1.useEffect)(function () {
         if (typeof localStorage !== "undefined") {
-            if (persistence && isLSReady) {
+            var windowExists = typeof window !== "undefined";
+            // For react native
+            var isBrowserEnv = windowExists && "addEventListener" in window;
+            if (persistence && isBrowserEnv ? isLSReady : true) {
                 if (localStorage["store-".concat(init.name)] !== defaultAtomsValues[init.name]) {
                     localStorage.setItem("store-".concat(init.name), JSON.stringify(state));
                 }
@@ -445,13 +448,7 @@ function filter(init) {
     var useFilterGet = function () {
         function getInitialValue() {
             try {
-                return typeof defaultFiltersValues["".concat(name)] === "undefined"
-                    ? (function () {
-                        return get(getObject);
-                    })()
-                    : (function () {
-                        return defaultFiltersValues["".concat(name)];
-                    })();
+                return defaultFiltersValues["".concat(name)];
             }
             catch (err) {
                 return init.default;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atomic-state",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "State managment library for React",
   "main": "index.js",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -408,7 +408,12 @@ function useAtomCreate<R, ActionsArgs>(init: Atom<R, ActionsArgs>) {
 
   useEffect(() => {
     if (typeof localStorage !== "undefined") {
-      if (persistence && isLSReady) {
+      const windowExists = typeof window !== "undefined"
+
+      // For react native
+      const isBrowserEnv = windowExists && "addEventListener" in window
+
+      if (persistence && isBrowserEnv ? isLSReady : true) {
         if (
           localStorage[`store-${init.name}`] !== defaultAtomsValues[init.name]
         ) {
@@ -520,13 +525,7 @@ export function filter<R>(init: Filter<R | Promise<R>>) {
   const useFilterGet = () => {
     function getInitialValue() {
       try {
-        return typeof defaultFiltersValues[`${name}`] === "undefined"
-          ? (() => {
-              return get(getObject)
-            })()
-          : (() => {
-              return defaultFiltersValues[`${name}`]
-            })()
+        return defaultFiltersValues[`${name}`]
       } catch (err) {
         return init.default
       }


### PR DESCRIPTION
When using persistence, only wait for data to be loaded when 'addEventListener' is supported (browsers)