### PR TITLE
FEAT:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 yarn.lock
 package-lock.json
+lib/types.js

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -4,55 +4,10 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React, { Dispatch, SetStateAction } from "react";
-/**
- * Atom type
- */
-export declare type Atom<T = any, ActionArgs = any> = {
-    name: string;
-    default?: T | Promise<T> | (() => Promise<T>) | (() => T);
-    localStoragePersistence?: boolean;
-    /**
-     * Short for `localStoragePersistence`
-     */
-    persist?: boolean;
-    /**
-     * If true, `persist` will keep the value in sync between tabs.
-     * By default it's `true`
-     */
-    sync?: boolean;
-    /**
-     * If `persist` is true, this will run whenever the state is updated from another tab. This will not run in the tab that updated the state.
-     */
-    onSync?(message: T): void;
-    /**
-     * If false, no warning for duplicate keys will be shown
-     */
-    ignoreKeyWarning?: boolean;
-    /**
-     * @deprecated
-     * This is for use when `localStoragePersistence` is `true`
-     * By default it's false. This is to prevent hydration errors.
-     * If set to `false`, data from localStorage will be loaded during render, not after.
-     * May have some bugs
-     */
-    hydration?: boolean;
-    actions?: {
-        [E in keyof ActionArgs]: (st: {
-            args: ActionArgs[E];
-            state: T;
-            dispatch: Dispatch<SetStateAction<T>>;
-        }) => void;
-    };
-    effects?: ((s: {
-        previous: T;
-        state: T;
-        dispatch: Dispatch<SetStateAction<T>>;
-    }) => void)[];
-};
-declare type ActionsObjectType<ArgsTypes = any> = {
-    [E in keyof ArgsTypes]: (args?: ArgsTypes[E]) => any;
-};
+import React from "react";
+import { Observervable, createObserver } from "./observable";
+import { ActionsObjectType, Atom, Filter, FilterGet, useAtomType } from "./types";
+export { Observervable, createObserver, ActionsObjectType, Atom, Filter, FilterGet, useAtomType, };
 export declare const AtomicState: React.FC<{
     children: any;
     /**
@@ -73,21 +28,6 @@ export declare const AtomicState: React.FC<{
  */
 export declare function atom<R, ActionsArgs = any>(init: Atom<R, ActionsArgs>): Atom<R, ActionsArgs>;
 export declare const createAtom: typeof atom;
-declare type useAtomType<R, ActionsArgs = any> = () => (R | Dispatch<SetStateAction<R>> | ActionsObjectType<ActionsArgs>)[];
-/**
- * Type for the `get` function of filters
- */
-export declare type FilterGet = {
-    get<R>(atom: useAtomType<R> | Atom<R, any>): R;
-};
-/**
- * Filter type
- */
-export declare type Filter<T = any> = {
-    name?: string;
-    default?: T;
-    get(c: FilterGet): T;
-};
 export declare function filter<R>(init: Filter<R | Promise<R>>): {
     (): R;
     "filter-name": string;
@@ -137,4 +77,3 @@ export declare const storage: {
  * this hook will update its state
  */
 export declare function useStorageItem<T = any>(k: string, def?: T): T;
-export {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,22 +42,13 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.useStorageItem = exports.storage = exports.useStorage = exports.useAtomActions = exports.useActions = exports.useAtomDispatch = exports.useDispatch = exports.useAtomValue = exports.useValue = exports.useAtom = exports.useFilter = exports.filter = exports.createAtom = exports.atom = exports.AtomicState = void 0;
-var events_1 = require("events");
+exports.useStorageItem = exports.storage = exports.useStorage = exports.useAtomActions = exports.useActions = exports.useAtomDispatch = exports.useDispatch = exports.useAtomValue = exports.useValue = exports.useAtom = exports.useFilter = exports.filter = exports.createAtom = exports.atom = exports.AtomicState = exports.createObserver = exports.Observervable = void 0;
 var react_1 = require("react");
+var observable_1 = require("./observable");
+Object.defineProperty(exports, "Observervable", { enumerable: true, get: function () { return observable_1.Observervable; } });
+Object.defineProperty(exports, "createObserver", { enumerable: true, get: function () { return observable_1.createObserver; } });
 var is18 = parseInt(react_1.version.split(".")[0]) >= 18;
-var atomEmitters = {};
-function createEmitter() {
-    var emitter = new events_1.EventEmitter();
-    emitter.setMaxListeners(10e12);
-    function notify(storeName, hookCall, payload) {
-        emitter.emit(storeName, { storeName: storeName, hookCall: hookCall, payload: payload });
-    }
-    return {
-        emitter: emitter,
-        notify: notify,
-    };
-}
+var atomObserverables = {};
 var defaultAtomsValues = {};
 var defaultAtomsInAtomic = {};
 var defaultFiltersInAtomic = {};
@@ -211,10 +202,10 @@ function useAtomCreate(init) {
     if (!pendingAtoms[init.name]) {
         pendingAtoms[init.name] = 0;
     }
-    if (!atomEmitters[init.name]) {
-        atomEmitters[init.name] = createEmitter();
+    if (!atomObserverables[init.name]) {
+        atomObserverables[init.name] = (0, observable_1.createObserver)();
     }
-    var _g = atomEmitters[init.name], emitter = _g.emitter, notify = _g.notify;
+    var _g = atomObserverables[init.name], observer = _g.observer, notify = _g.notify;
     var _h = (0, react_1.useState)(false), runEffects = _h[0], setRunEffects = _h[1];
     var hydrated = (0, react_1.useRef)(false);
     var updateState = (0, react_1.useCallback)(function (v) { return __awaiter(_this, void 0, void 0, function () {
@@ -374,7 +365,7 @@ function useAtomCreate(init) {
                             else {
                                 pendingAtoms[init.name] += 1;
                                 if (state || defaultAtomsValues[init.name]) {
-                                    atomEmitters[init.name].notify(init.name, hookCall, state || defaultAtomsValues[init.name]);
+                                    atomObserverables[init.name].notify(init.name, hookCall, state || defaultAtomsValues[init.name]);
                                 }
                             }
                         }
@@ -403,9 +394,9 @@ function useAtomCreate(init) {
                 return [2 /*return*/];
             });
         }); };
-        emitter.addListener(init.name, handler);
+        observer.addSubscriber(init.name, handler);
         return function () {
-            emitter.removeListener(init.name, handler);
+            observer.removeSubscriber(init.name, handler);
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [runEffects]);
@@ -468,18 +459,18 @@ exports.createAtom = atom;
 var defaultFiltersValues = {};
 var objectFilters = {};
 var resolvedFilters = {};
-var filterEmitters = {};
+var filterObservables = {};
 var subscribedFilters = {};
 function filter(init) {
     var _a = init.name, name = _a === void 0 ? "" : _a, get = init.get;
     var filterDeps = {};
     var depsValues = {};
-    if (!filterEmitters[name]) {
-        filterEmitters[name] = createEmitter();
+    if (!filterObservables[name]) {
+        filterObservables[name] = (0, observable_1.createObserver)();
     }
-    var filterEmitter = filterEmitters[name];
+    var filterObservers = filterObservables[name];
     function notifyOtherFilters(hookCall, payload) {
-        filterEmitter.notify(name, hookCall, payload);
+        filterObservers.notify(name, hookCall, payload);
     }
     var getObject = {
         get: function (atom) {
@@ -517,12 +508,12 @@ function filter(init) {
                 subscribedFilters[name] = true;
                 get(getObject);
                 for (var dep in filterDeps) {
-                    (_a = atomEmitters[dep]) === null || _a === void 0 ? void 0 : _a.emitter.addListener(dep, renderValue);
+                    (_a = atomObserverables[dep]) === null || _a === void 0 ? void 0 : _a.observer.addSubscriber(dep, renderValue);
                 }
                 return function () {
                     var _a;
                     for (var dep in filterDeps) {
-                        (_a = atomEmitters[dep]) === null || _a === void 0 ? void 0 : _a.emitter.removeListener(dep, renderValue);
+                        (_a = atomObserverables[dep]) === null || _a === void 0 ? void 0 : _a.observer.removeSubscriber(dep, renderValue);
                     }
                 };
             }
@@ -574,7 +565,7 @@ function filter(init) {
                 });
             });
         }
-        function updateValueFromEvent(e) {
+        function updateValueFromObservableChange(e) {
             return __awaiter(this, void 0, void 0, function () {
                 var storeName, payload;
                 return __generator(this, function (_a) {
@@ -591,12 +582,12 @@ function filter(init) {
         }, [filterValue]);
         (0, react_1.useEffect)(function () {
             var _a;
-            (_a = filterEmitter.emitter) === null || _a === void 0 ? void 0 : _a.addListener(name, updateValueFromEvent);
+            (_a = filterObservers.observer) === null || _a === void 0 ? void 0 : _a.addSubscriber(name, updateValueFromObservableChange);
             return function () {
                 var _a;
                 subscribedFilters[name] = false;
                 resolvedFilters[name] = false;
-                (_a = filterEmitter === null || filterEmitter === void 0 ? void 0 : filterEmitter.emitter) === null || _a === void 0 ? void 0 : _a.removeListener(name, updateValueFromEvent);
+                (_a = filterObservers === null || filterObservers === void 0 ? void 0 : filterObservers.observer) === null || _a === void 0 ? void 0 : _a.removeSubscriber(name, updateValueFromObservableChange);
             };
         }, [init]);
         return filterValue;
@@ -668,9 +659,8 @@ exports.useActions = useActions;
 exports.useAtomActions = useActions;
 // Selectors section
 // localStorage utilities for web apps
-var storageEmitter = (function () {
-    var emm = new events_1.EventEmitter();
-    emm.setMaxListeners(Math.pow(10, 10));
+var storageOvservable = (function () {
+    var emm = new observable_1.Observervable();
     return emm;
 })();
 /**
@@ -706,9 +696,9 @@ function useStorage(defaults) {
         updateStore();
     }, []);
     (0, react_1.useEffect)(function () {
-        storageEmitter.addListener("store-changed", updateStore);
+        storageOvservable.addSubscriber("store-changed", updateStore);
         return function () {
-            storageEmitter.removeListener("store-changed", updateStore);
+            storageOvservable.removeSubscriber("store-changed", updateStore);
         };
     }, []);
     return keys;
@@ -722,7 +712,7 @@ exports.storage = {
         if (typeof localStorage !== "undefined") {
             if (typeof localStorage.setItem === "function") {
                 localStorage.setItem(k, JSON.stringify(v));
-                storageEmitter.emit("store-changed", v);
+                storageOvservable.update("store-changed", v);
             }
         }
     },
@@ -735,7 +725,7 @@ exports.storage = {
                 if (typeof localStorage !== "undefined") {
                     if (typeof localStorage.removeItem === "function") {
                         localStorage.removeItem(k);
-                        storageEmitter.emit("store-changed", {});
+                        storageOvservable.update("store-changed", {});
                     }
                 }
                 return [2 /*return*/];
@@ -778,7 +768,7 @@ exports.storage = {
 function useStorageItem(k, def) {
     if (def === void 0) { def = null; }
     var _a = (0, react_1.useState)(def), value = _a[0], setValue = _a[1];
-    var itemListener = function () {
+    var itemObserver = function () {
         if (typeof localStorage !== "undefined") {
             if (JSON.stringify(localStorage[k]) !== JSON.stringify(def)) {
                 try {
@@ -791,10 +781,10 @@ function useStorageItem(k, def) {
         }
     };
     (0, react_1.useEffect)(function () {
-        itemListener();
-        storageEmitter.addListener("store-changed", itemListener);
+        itemObserver();
+        storageOvservable.addSubscriber("store-changed", itemObserver);
         return function () {
-            storageEmitter.removeListener("store-changed", itemListener);
+            storageOvservable.removeSubscriber("store-changed", itemObserver);
         };
     }, []);
     return value;

--- a/lib/observable.d.ts
+++ b/lib/observable.d.ts
@@ -1,0 +1,14 @@
+/**
+ * An observable class that uses the observer pattern
+ */
+export declare class Observervable {
+    suscribers: any;
+    constructor();
+    addSubscriber(messageName: string, subscriber: any): Promise<void>;
+    removeSubscriber(messageName: string, subscriber: any): Promise<void>;
+    update(messageName: string, payload: any): Promise<void>;
+}
+export declare function createObserver(): {
+    observer: Observervable;
+    notify: (storeName: string, hookCall: string, payload: any) => void;
+};

--- a/lib/observable.d.ts
+++ b/lib/observable.d.ts
@@ -2,7 +2,7 @@
  * An observable class that uses the observer pattern
  */
 export declare class Observervable {
-    suscribers: any;
+    private suscribers;
     constructor();
     addSubscriber(messageName: string, subscriber: any): Promise<void>;
     removeSubscriber(messageName: string, subscriber: any): Promise<void>;

--- a/lib/observable.js
+++ b/lib/observable.js
@@ -52,7 +52,12 @@ var Observervable = /** @class */ (function () {
                     this.suscribers[messageName] = {};
                 }
                 subscriberId = Object.keys(this.suscribers[messageName]).length + 1;
-                this.suscribers[messageName][subscriberId] = subscriber;
+                if (messageName !== "__proto__" && messageName !== "prototype") {
+                    this.suscribers[messageName][subscriberId] = subscriber;
+                }
+                else {
+                    console.warn('"prototype" and "__proto__" are not valid message names');
+                }
                 return [2 /*return*/];
             });
         });

--- a/lib/observable.js
+++ b/lib/observable.js
@@ -1,0 +1,112 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.createObserver = exports.Observervable = void 0;
+/**
+ * An observable class that uses the observer pattern
+ */
+var Observervable = /** @class */ (function () {
+    function Observervable() {
+        this.suscribers = {};
+    }
+    Observervable.prototype.addSubscriber = function (messageName, subscriber) {
+        return __awaiter(this, void 0, void 0, function () {
+            var subscriberId;
+            return __generator(this, function (_a) {
+                if (!(messageName in this.suscribers)) {
+                    this.suscribers[messageName] = {};
+                }
+                subscriberId = Object.keys(this.suscribers[messageName]).length + 1;
+                this.suscribers[messageName][subscriberId] = subscriber;
+                return [2 /*return*/];
+            });
+        });
+    };
+    Observervable.prototype.removeSubscriber = function (messageName, subscriber) {
+        return __awaiter(this, void 0, void 0, function () {
+            var observer;
+            return __generator(this, function (_a) {
+                for (observer in this.suscribers[messageName]) {
+                    if (this.suscribers[messageName][observer] === subscriber) {
+                        delete this.suscribers[messageName][observer];
+                    }
+                }
+                return [2 /*return*/];
+            });
+        });
+    };
+    Observervable.prototype.update = function (messageName, payload) {
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, _b, _i, subscribers;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        _a = [];
+                        for (_b in this.suscribers[messageName])
+                            _a.push(_b);
+                        _i = 0;
+                        _c.label = 1;
+                    case 1:
+                        if (!(_i < _a.length)) return [3 /*break*/, 4];
+                        subscribers = _a[_i];
+                        return [4 /*yield*/, this.suscribers[messageName][subscribers](payload)];
+                    case 2:
+                        _c.sent();
+                        _c.label = 3;
+                    case 3:
+                        _i++;
+                        return [3 /*break*/, 1];
+                    case 4: return [2 /*return*/];
+                }
+            });
+        });
+    };
+    return Observervable;
+}());
+exports.Observervable = Observervable;
+function createObserver() {
+    var observer = new Observervable();
+    function notify(storeName, hookCall, payload) {
+        observer.update(storeName, { storeName: storeName, hookCall: hookCall, payload: payload });
+    }
+    return {
+        observer: observer,
+        notify: notify,
+    };
+}
+exports.createObserver = createObserver;

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,0 +1,64 @@
+import { Dispatch, SetStateAction } from "react";
+/**
+ * Atom type
+ */
+export declare type Atom<T = any, ActionArgs = any> = {
+    name: string;
+    default?: T | Promise<T> | (() => Promise<T>) | (() => T);
+    localStoragePersistence?: boolean;
+    /**
+     * Short for `localStoragePersistence`
+     */
+    persist?: boolean;
+    /**
+     * If true, `persist` will keep the value in sync between tabs.
+     * By default it's `true`
+     */
+    sync?: boolean;
+    /**
+     * If `persist` is true, this will run whenever the state is updated from another tab. This will not run in the tab that updated the state.
+     */
+    onSync?(message: T): void;
+    /**
+     * If false, no warning for duplicate keys will be shown
+     */
+    ignoreKeyWarning?: boolean;
+    /**
+     * @deprecated
+     * This is for use when `localStoragePersistence` is `true`
+     * By default it's false. This is to prevent hydration errors.
+     * If set to `false`, data from localStorage will be loaded during render, not after.
+     * May have some bugs
+     */
+    hydration?: boolean;
+    actions?: {
+        [E in keyof ActionArgs]: (st: {
+            args: ActionArgs[E];
+            state: T;
+            dispatch: Dispatch<SetStateAction<T>>;
+        }) => void;
+    };
+    effects?: ((s: {
+        previous: T;
+        state: T;
+        dispatch: Dispatch<SetStateAction<T>>;
+    }) => void)[];
+};
+export declare type ActionsObjectType<ArgsTypes = any> = {
+    [E in keyof ArgsTypes]: (args?: ArgsTypes[E]) => any;
+};
+export declare type useAtomType<R, ActionsArgs = any> = () => (R | Dispatch<SetStateAction<R>> | ActionsObjectType<ActionsArgs>)[];
+/**
+ * Type for the `get` function of filters
+ */
+export declare type FilterGet = {
+    get<R>(atom: useAtomType<R> | Atom<R, any>): R;
+};
+/**
+ * Filter type
+ */
+export declare type Filter<T = any> = {
+    name?: string;
+    default?: T;
+    get(c: FilterGet): T;
+};

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "atomic-state",
-  "version": "1.7.9",
+  "version": "1.8.0",
   "description": "State managment library for React",
-  "main": "index.js",
+  "main": "lib/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/atomic-state/atomic-state"
@@ -20,17 +20,16 @@
   "license": "MIT",
   "homepage": "https://github.com/atomic-state/atomic-state#readme",
   "devDependencies": {
-    "react": ">=16.13.1",
-    "react-dom": ">=16.13.1",
     "@babel/preset-env": "^7.15.8",
     "@babel/preset-react": "^7.14.5",
     "@testing-library/react": "^12.1.2",
-    "@types/events": "^3.0.0",
     "@types/jest": "^27.0.2",
     "@types/react": "17.0.27",
     "@types/react-dom": "17.0.9",
     "babel-jest": "27.2.5",
     "jest": "27.2.5",
+    "react": ">=16.13.1",
+    "react-dom": ">=16.13.1",
     "react-test-renderer": "17.0.2",
     "ts-jest": "27.0.5",
     "typescript": "4.4.4"
@@ -39,7 +38,5 @@
     "react": ">=16.13.1",
     "react-dom": ">=16.13.1"
   },
-  "dependencies": {
-    "events": "3.3.0"
-  }
+  "dependencies": {}
 }

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -1,0 +1,39 @@
+/**
+ * An observable class that uses the observer pattern
+ */
+export class Observervable {
+  suscribers: any
+  constructor() {
+    this.suscribers = {}
+  }
+  async addSubscriber(messageName: string, subscriber: any) {
+    if (!(messageName in this.suscribers)) {
+      this.suscribers[messageName] = {}
+    }
+    let subscriberId = Object.keys(this.suscribers[messageName]).length + 1
+    this.suscribers[messageName][subscriberId] = subscriber
+  }
+  async removeSubscriber(messageName: string, subscriber: any) {
+    for (let observer in this.suscribers[messageName]) {
+      if (this.suscribers[messageName][observer] === subscriber) {
+        delete this.suscribers[messageName][observer]
+      }
+    }
+  }
+  async update(messageName: string, payload: any) {
+    for (let subscribers in this.suscribers[messageName]) {
+      await this.suscribers[messageName][subscribers](payload)
+    }
+  }
+}
+
+export function createObserver() {
+  const observer = new Observervable()
+  function notify(storeName: string, hookCall: string, payload: any) {
+    observer.update(storeName, { storeName, hookCall, payload })
+  }
+  return {
+    observer: observer,
+    notify,
+  }
+}

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -2,7 +2,7 @@
  * An observable class that uses the observer pattern
  */
 export class Observervable {
-  suscribers: any
+  private suscribers: any
   constructor() {
     this.suscribers = {}
   }
@@ -11,7 +11,11 @@ export class Observervable {
       this.suscribers[messageName] = {}
     }
     let subscriberId = Object.keys(this.suscribers[messageName]).length + 1
-    this.suscribers[messageName][subscriberId] = subscriber
+    if (messageName !== "__proto__" && messageName !== "prototype") {
+      this.suscribers[messageName][subscriberId] = subscriber
+    } else {
+      console.warn('"prototype" and "__proto__" are not valid message names')
+    }
   }
   async removeSubscriber(messageName: string, subscriber: any) {
     for (let observer in this.suscribers[messageName]) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,73 @@
+import { Dispatch, SetStateAction } from "react"
+
+/**
+ * Atom type
+ */
+export type Atom<T = any, ActionArgs = any> = {
+  name: string
+  default?: T | Promise<T> | (() => Promise<T>) | (() => T)
+  localStoragePersistence?: boolean
+  /**
+   * Short for `localStoragePersistence`
+   */
+  persist?: boolean
+  /**
+   * If true, `persist` will keep the value in sync between tabs.
+   * By default it's `true`
+   */
+  sync?: boolean
+  /**
+   * If `persist` is true, this will run whenever the state is updated from another tab. This will not run in the tab that updated the state.
+   */
+  onSync?(message: T): void
+  /**
+   * If false, no warning for duplicate keys will be shown
+   */
+  ignoreKeyWarning?: boolean
+  /**
+   * @deprecated
+   * This is for use when `localStoragePersistence` is `true`
+   * By default it's false. This is to prevent hydration errors.
+   * If set to `false`, data from localStorage will be loaded during render, not after.
+   * May have some bugs
+   */
+  hydration?: boolean
+  actions?: {
+    [E in keyof ActionArgs]: (st: {
+      args: ActionArgs[E]
+      state: T
+      dispatch: Dispatch<SetStateAction<T>>
+    }) => void
+  }
+  effects?: ((s: {
+    previous: T
+    state: T
+    dispatch: Dispatch<SetStateAction<T>>
+  }) => void)[]
+}
+
+export type ActionsObjectType<ArgsTypes = any> = {
+  [E in keyof ArgsTypes]: (args?: ArgsTypes[E]) => any
+}
+
+export type useAtomType<R, ActionsArgs = any> = () => (
+  | R
+  | Dispatch<SetStateAction<R>>
+  | ActionsObjectType<ActionsArgs>
+)[]
+
+/**
+ * Type for the `get` function of filters
+ */
+export type FilterGet = {
+  get<R>(atom: useAtomType<R> | Atom<R, any>): R
+}
+
+/**
+ * Filter type
+ */
+export type Filter<T = any> = {
+  name?: string
+  default?: T
+  get(c: FilterGet): T
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     // "watch": true,
-    "outDir": "./",
+    "outDir": "./lib",
     "module": "commonjs",
     "esModuleInterop": true,
     "target": "es5",


### PR DESCRIPTION
- Uses a custom observer implementation class instead of using the EventEmitter class. It is available as 'Observable'
- moved all types to the same file, they are still available when importing from 'atomic-state'

These are not breaking changes