### PR TITLE
FIX(filters):

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -398,10 +398,7 @@ function useAtomCreate(init) {
         var handler = function (e) { return __awaiter(_this, void 0, void 0, function () {
             return __generator(this, function (_a) {
                 if (e.hookCall !== hookCall) {
-                    // const tm = setTimeout(() => {
                     setState(e.payload);
-                    //   clearTimeout(tm)
-                    // }, 0)
                 }
                 return [2 /*return*/];
             });
@@ -505,10 +502,15 @@ function filter(init) {
     var useFilterGet = function () {
         var hookCall = (0, react_1.useMemo)(function () { return Math.random(); }, []);
         function getInitialValue() {
+            var beforeGet = subscribedFilters[name]
+                ? defaultFiltersValues[init.name]
+                : get(getObject);
             try {
                 resolvedFilters["".concat(name)] = true;
                 return typeof defaultFiltersValues["".concat(name)] === "undefined"
-                    ? init.default
+                    ? typeof beforeGet === "undefined"
+                        ? init.default
+                        : beforeGet
                     : defaultFiltersValues["".concat(name)];
             }
             catch (err) {
@@ -521,7 +523,7 @@ function filter(init) {
             // Whenever the filter object / function changes, add atoms deps again
             if (!subscribedFilters[name]) {
                 subscribedFilters[name] = true;
-                get(getObject);
+                // get(getObject)
                 for (var dep in filterDeps) {
                     (_a = atomObservables[dep]) === null || _a === void 0 ? void 0 : _a.observer.addSubscriber(dep, renderValue);
                 }
@@ -550,7 +552,7 @@ function filter(init) {
         }, [initialValue]);
         function renderValue(e) {
             return __awaiter(this, void 0, void 0, function () {
-                var newValue_1, tm_1, err_4;
+                var newValue, err_4;
                 return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
@@ -560,17 +562,9 @@ function filter(init) {
                             _a.trys.push([1, 3, , 4]);
                             return [4 /*yield*/, get(getObject)];
                         case 2:
-                            newValue_1 = _a.sent();
-                            defaultFiltersValues["".concat(name)] = newValue_1;
-                            if (is18) {
-                                setFilterValue(newValue_1);
-                            }
-                            else {
-                                tm_1 = setTimeout(function () {
-                                    setFilterValue(newValue_1);
-                                    clearTimeout(tm_1);
-                                }, 0);
-                            }
+                            newValue = _a.sent();
+                            defaultFiltersValues["".concat(name)] = newValue;
+                            setFilterValue(newValue);
                             return [3 /*break*/, 4];
                         case 3:
                             err_4 = _a.sent();

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -58,7 +58,7 @@ export declare type FilterGet = {
  * Filter type
  */
 export declare type Filter<T = any> = {
-    name?: string;
+    name: string;
     default?: T;
     get(c: FilterGet): T;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atomic-state",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "State managment library for React",
   "main": "lib/index.js",
   "repository": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,7 +67,7 @@ export type FilterGet = {
  * Filter type
  */
 export type Filter<T = any> = {
-  name?: string
+  name: string
   default?: T
   get(c: FilterGet): T
 }


### PR DESCRIPTION
By default, filters will try to read the current value of atoms in the first render and not in the second. This resolves a problem of filters having an 'undefined' value in the first render when not specifying the 'default' property