### PR TITLE
feat(createStore):

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atomic-state",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Atomic State is a managment library for React",
   "main": "dist/index.js",
   "repository": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,4 +27,5 @@ export {
   useStorageItem,
   useValue,
   session,
+  createStore,
 } from "./mod"


### PR DESCRIPTION
Adds the `createStore` function, which returns a hook that returns an array with the state and an actions object to help update the state. This can help create global states with less boilerplate.
Example usage:

```tsx
import { createStore } from 'atomic-state'

// Fully typed global state
const useGlobalStore = createStore({
  name: 'globalStore',
  default: {
    name: 'Dany',
    count: 0
  },
  persist: true
})

export default function Page() {
  const [globalStore, actions] = useGlobalStore()
  return (
    <div>
      <h2>Name: {globalStore.name}</h2>
      <h2>Count: {globalStore.count}</h2>
      <button
        onClick={() => {
          actions.push(prev => ({ count: prev.count + 1 }))
        }}
      >
        Increase
      </button>
      <button onClick={actions.reset}>Restart</button>
      <input
        type='text'
        value={globalStore.name}
        onChange={e => {
          actions.push(() => ({
            name: e.target.value
          }))
        }}
      />
    </div>
  )
}

```

### Using the store atom

The function returned by `createStore` has the `atom` property added. That is the atom created internally by `createStore`, so this sould still work:

```js
const [globalStore, setGlobalStore actions] = useAtom(useGlobalStore.atom)
```