### PR TITLE
feat(PersistenceProvider):

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ yarn add atomic-state
 <script src="https://unpkg.com/atomic-state/browser/atomic-state.min.js"></script>
 ```
 
-[Getting started](https://atomic-state.org/docs/intro)
+[Getting started](https://atomic-state.netlify.app/docs)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atomic-state",
-  "version": "2.3.8",
+  "version": "2.4.0",
   "description": "Atomic State is a state management library for React",
   "main": "dist/index.js",
   "repository": {
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "compile": "tsc",
-    "test": "jest"
+    "test": "tsc && jest"
   },
   "keywords": [
     "State managment",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,4 +31,5 @@ export {
   useValue,
   session,
   createAtomicHook,
+  createPersistence,
 } from "./mod"

--- a/src/mod.tsx
+++ b/src/mod.tsx
@@ -160,6 +160,8 @@ export type PersistenceStoreType = {
   remove?: PersistenceRemove
   removeItem?: PersistenceRemove
   removeItemAsync?: PersistenceRemove
+  delete?: PersistenceRemove
+  deleteItem?: PersistenceRemove
   deleteItemAsync?: PersistenceRemove
 }
 
@@ -191,6 +193,8 @@ export function createPersistence(
     persistenceProvider.removeItem ??
     persistenceProvider.remove ??
     persistenceProvider.removeItemAsync ??
+    persistenceProvider.delete ??
+    persistenceProvider.deleteItem ??
     persistenceProvider.deleteItemAsync ??
     (() => {})
 


### PR DESCRIPTION
### Improvements in persistence

Atomic state will try to call specific functions in the passed `persistenceProvider`.

This means you can now pass any object as PersistenceProvider that doesn't necessarily have the `getItem`, `setItem` and `removeItem` methods. It can now have the following methods:

For setting an item: `set`, `setItem`, `setItemAsync`
For getting an item: `get`, `getItem`, `getItemAsync`
For removing an item: `remove`, `removeItem`, `removeItemAsync`, `delete`, `deleteItem`, `deleteItemAsync`.

#### Example
You can use `js-cookies` without creating an object with the same properties as `localStorage`. Just pass it as `persistenceProvider` when creating an atom or in the `<AtomicState>` root and it will work just fine:

```tsx
import { atom, useAtom } from "atomic-state"

import Cookies from "js-cookie"

const countState = atom({
  name: "count",
  default: 0,
  persist: true,
  persistenceProvider: Cookies,
})

export default function Home() {
  const [count, setCount] = useAtom(countState)

  return (
    <main>
      <h2>{count}</h2>
      <button onClick={() => setCount((c) => c + 1)}>Add</button>
    </main>
  )
}
```