### PR TITLE
enh(prefix):

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atomic-state",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Atomic State is a state management library for React",
   "main": "dist/index.js",
   "repository": {


### PR DESCRIPTION
`prefix` is now opt-in. The key used to save an atom's value is just the atom's name and it does not include a 'store-' or `-` by default