### PR TITLE
feat(atoms, selectors):

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atomic-state",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Atomic State is a state management library for React",
   "main": "dist/index.js",
   "repository": {

--- a/src/mod.tsx
+++ b/src/mod.tsx
@@ -922,25 +922,32 @@ const ignoredAtomKeyWarnings: any = {}
 /**
  * Creates an atom containing state
  */
-export function atom<R, ActionsArgs = any>(init: Atom<R, ActionsArgs>) {
-  if (!init.name) {
-    init.name = init.key as string
+export function atom<R, ActionsArgs = any>(
+  $init: Atom<R, ActionsArgs> | Filter<R>
+) {
+  if ("get" in $init) {
+    return filter($init as Filter<R>)
+  } else {
+    const init = $init as Atom<R, ActionsArgs>
+    if (!init.name) {
+      init.name = init.key as string
+    }
+
+    if (init.ignoreKeyWarning) {
+      ignoredAtomKeyWarnings[init.name] = true
+    }
+
+    usedKeys[init.name] = true
+
+    if (!atomsInitializeObjects[init?.name]) {
+      atomsInitializeObjects[init?.name] = init
+    }
+
+    const useCreate = () => useAtomCreate<R, ActionsArgs>(init)
+    useCreate["atom-name"] = init.name
+    useCreate["init-object"] = init
+    return useCreate as Atom<R, ActionsArgs>
   }
-
-  if (init.ignoreKeyWarning) {
-    ignoredAtomKeyWarnings[init.name] = true
-  }
-
-  usedKeys[init.name] = true
-
-  if (!atomsInitializeObjects[init?.name]) {
-    atomsInitializeObjects[init?.name] = init
-  }
-
-  const useCreate = () => useAtomCreate<R, ActionsArgs>(init)
-  useCreate["atom-name"] = init.name
-  useCreate["init-object"] = init
-  return useCreate as Atom<R, ActionsArgs>
 }
 export const createAtom = atom
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -39,12 +39,13 @@ export function getFilterValue<R>(
   return $filterValue
 }
 
-export function getValue<R = any>(init: Atom<R> | Filter<R>, prefix?: string) {
-  if (init.default) {
-    return getAtom(init, prefix)
-  } else return getFilter(init, prefix)
-}
-
 export const getAtom = getAtomValue
-export const getFilter = getAtomValue
+export const getFilter = getFilterValue
 export const getSelector = getFilterValue
+
+export function getValue<R = any>(init: Atom<R> | Filter<R>, prefix?: string) {
+  const isFilter = (init as any)["init-object"].get
+  if (!isFilter) {
+    return getAtom(init, prefix)
+  } else return getFilter(init as Filter<R>, prefix)
+}


### PR DESCRIPTION
- The `atom` function can now be used to create selectors
- Improve `getValue` function

Example:

```tsx
import { atom, useAtom, useValue } from 'atomic-state'

const countState = atom({
  key: 'count',
  default: 0
})

const doubleState = atom({
  key: 'double',
  get({ get }) {
    const count = get(countState)

    return count * 2
  }
})

export default function Home() {
  const [count, setCount] = useAtom(countState)

  const double = useValue(doubleState)

  return (
    <main>
      <h2>Count: {count}</h2>
      <p>Double: {double}</p>
      <hr />
      <button
        onClick={() => {
          // Normal setState
          setCount(c => c + 1)
        }}
      >
        +++
      </button>
    </main>
  )
}

```