### PR TITLE
enh-feat:

### DIFF
--- a/mocks/Tes1.tsx
+++ b/mocks/Tes1.tsx
@@ -1,14 +1,14 @@
 import React from "react"
 import { useDispatch, useValue } from "../"
-import { clicks } from "./atoms"
+import { clicksState } from "./atoms"
 
 export const RenderCount = () => {
-  const clicksCount = useValue(clicks)
+  const clicksCount = useValue(clicksState)
   return <h2>count is {clicksCount}</h2>
 }
 
 export const IncreaseButton = () => {
-  const setAtomValue = useDispatch(clicks)
+  const setAtomValue = useDispatch(clicksState)
 
   return (
     <div>

--- a/mocks/Test2.tsx
+++ b/mocks/Test2.tsx
@@ -1,14 +1,14 @@
 import React from "react"
 import { useAtom } from "../"
-import { nameAtom } from "./atoms"
+import { nameState } from "./atoms"
 
 export const NameDisplay = () => {
-  const [name] = useAtom(nameAtom)
+  const [name] = useAtom(nameState)
   return <p>Username: {name}</p>
 }
 
 export const NameField = () => {
-  const [name, setName] = useAtom(nameAtom)
+  const [name, setName] = useAtom(nameState)
   return (
     <div>
       <input

--- a/mocks/Test3.tsx
+++ b/mocks/Test3.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from "react"
-import { useDispatch, useFilter } from "../"
-import { clicks, clicksFilter, tripleCliksFilter } from "./atoms"
+import { useDispatch, useValue } from "../"
+import { clicksState, doubleClicksState, tripleClicksState } from "./atoms"
 
 export const RenderCountDouble = () => {
-  const constDoubleCount = useFilter(clicksFilter)
-  const tripleDoubleCount = useFilter(tripleCliksFilter)
+  const constDoubleCount = useValue(doubleClicksState)
+  const tripleDoubleCount = useValue(tripleClicksState)
 
   return (
     <h2>
@@ -14,7 +14,7 @@ export const RenderCountDouble = () => {
 }
 
 export const IncreaseButton2 = () => {
-  const setAtomValue = useDispatch(clicks)
+  const setAtomValue = useDispatch(clicksState)
 
   useEffect(() => {
     // Reset count when mounting to prevent conflicts with other tests

--- a/mocks/atoms.ts
+++ b/mocks/atoms.ts
@@ -1,28 +1,28 @@
-import { Atom, atom, filter } from "../"
+import { atom } from "../"
 
-export const clicks: Atom<number> = atom({
-  name: "clicks-count",
+export const clicksState = atom({
+  key: "clicks-count",
   default: 0,
 })
 
-export const nameAtom: Atom<string> = {
-  name: "user-name",
+export const nameState = atom({
+  key: "user-name",
   default: "",
-}
+})
 
-export const clicksFilter = filter({
-  name: "clicksFilter",
+export const doubleClicksState = atom({
+  key: "clicksFilter",
   default: 0,
   get({ get }) {
-    const count = get(clicks)
+    const count = get(clicksState)
     return count * 2
   },
 })
 
-export const tripleCliksFilter = filter({
-  name: "tripleCliksFilter",
-  get({ read }) {
-    const double = read(clicksFilter)
+export const tripleClicksState = atom({
+  key: "tripleCliksFilter",
+  get({ get }) {
+    const double = get(doubleClicksState)
     return double * 3
   },
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atomic-state",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "description": "Atomic State is a state management library for React",
   "main": "dist/index.js",
   "repository": {


### PR DESCRIPTION
### Enhancements

- Enhances the shape of the object returned from the `takeSnapshot` function

```js
const countState = atom({
  key: 'count',
  default: 1
})

const double = atom({
  key: 'double',
  get({ get }) {
    const count = get(countState)
    return count * 2
  }
})

const snapshot = takeSnapshot()

const defaultStore = snapshot.default // --> { count: 1, double: 2 }

```

- Improved the `get` function inside atom's actions
- atom's and selector's `name` is now deprecated and `key` is mandatory when creating atoms/selectors
- changed the `prefix` prop to `storeName` in the `<AtomicState>` root
- Removed the `filters` prop in the `<AtomicState>` root to use `selectors` instead
- Removed useless `ignoreKeyWarning` property from atom config