### PR TITLE
enh(atoms):

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": false,
+  "arrowParens": "avoid",
+  "singleQuote": true,
+  "jsxSingleQuote": true,
+  "trailingComma": "none"
+}

--- a/__tests__/atomic-state-tests.tsx
+++ b/__tests__/atomic-state-tests.tsx
@@ -1,9 +1,9 @@
-import React from "react"
-import { render, fireEvent, waitFor } from "@testing-library/react"
-import { RenderCount, IncreaseButton } from "../mocks/Tes1"
-import { NameDisplay, NameField } from "../mocks/Test2"
-import { RenderCountDouble, IncreaseButton2 } from "../mocks/Test3"
-import { act } from "react-dom/test-utils"
+import React from 'react'
+import { render, fireEvent, waitFor } from '@testing-library/react'
+import { RenderCount, IncreaseButton } from '../mocks/Tes1'
+import { NameDisplay, NameField } from '../mocks/Test2'
+import { RenderCountDouble, IncreaseButton2 } from '../mocks/Test3'
+import { act } from 'react-dom/test-utils'
 
 it("Should increase clicks' atom value", async () => {
   const Button = render(<IncreaseButton />)
@@ -13,11 +13,11 @@ it("Should increase clicks' atom value", async () => {
   })
 
   await waitFor(() => {
-    expect(CountDisplay.queryByText(/count is /)!.innerHTML).toBe("count is 1")
+    expect(CountDisplay.queryByText(/count is /)!.innerHTML).toBe('count is 1')
   })
 })
 
-it("Should show the double of the count atom", async () => {
+it('Should show the double of the count atom', async () => {
   const Button = render(<IncreaseButton2 />)
   const CountDisplay = render(<RenderCountDouble />)
   act(() => {
@@ -29,7 +29,7 @@ it("Should show the double of the count atom", async () => {
 
   await waitFor(() => {
     expect(CountDisplay.queryByText(/double is /)!.innerHTML).toBe(
-      "double is 4, triple is 12"
+      'double is 4, triple is 12'
     )
   })
 })
@@ -40,14 +40,14 @@ it("Should update an atom's value on user input", async () => {
   act(() => {
     fireEvent.change(Field.getByTitle(/name field/), {
       target: {
-        value: "inuyasha",
-      },
+        value: 'inuyasha'
+      }
     })
   })
 
   await waitFor(() => {
     expect(NameDisp.queryByText(/Username:/)!.innerHTML).toBe(
-      "Username: inuyasha"
+      'Username: inuyasha'
     )
   })
 })

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = { presets: ["@babel/preset-env", "@babel/preset-react"] };
+module.exports = { presets: ['@babel/preset-env', '@babel/preset-react'] }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,8 @@
 module.exports = {
-  testEnvironment: "jsdom",
-  preset: "ts-jest",
+  testEnvironment: 'jsdom',
+  preset: 'ts-jest',
   transform: {
-    "^.+\\.(ts|tsx)?$": "ts-jest",
-    "^.+\\.(js|jsx)$": "babel-jest",
-  },
-};
+    '^.+\\.(ts|tsx)?$': 'ts-jest',
+    '^.+\\.(js|jsx)$': 'babel-jest'
+  }
+}

--- a/mocks/Tes1.tsx
+++ b/mocks/Tes1.tsx
@@ -1,6 +1,6 @@
-import React from "react"
-import { useDispatch, useValue } from "../"
-import { clicksState } from "./atoms"
+import React from 'react'
+import { useDispatch, useValue } from '../'
+import { clicksState } from './atoms'
 
 export const RenderCount = () => {
   const clicksCount = useValue(clicksState)
@@ -12,9 +12,7 @@ export const IncreaseButton = () => {
 
   return (
     <div>
-      <button onClick={() => setAtomValue((value) => value + 1)}>
-        increase
-      </button>
+      <button onClick={() => setAtomValue(value => value + 1)}>increase</button>
     </div>
   )
 }

--- a/mocks/Test2.tsx
+++ b/mocks/Test2.tsx
@@ -1,6 +1,6 @@
-import React from "react"
-import { useAtom } from "../"
-import { nameState } from "./atoms"
+import React from 'react'
+import { useAtom } from '../'
+import { nameState } from './atoms'
 
 export const NameDisplay = () => {
   const [name] = useAtom(nameState)
@@ -12,10 +12,10 @@ export const NameField = () => {
   return (
     <div>
       <input
-        title="name field"
-        type="text"
+        title='name field'
+        type='text'
         value={name}
-        onChange={(e) => setName(e.target.value)}
+        onChange={e => setName(e.target.value)}
       />
     </div>
   )

--- a/mocks/Test3.tsx
+++ b/mocks/Test3.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from "react"
-import { useDispatch, useValue } from "../"
-import { clicksState, doubleClicksState, tripleClicksState } from "./atoms"
+import React, { useEffect } from 'react'
+import { useDispatch, useValue } from '../'
+import { clicksState, doubleClicksState, tripleClicksState } from './atoms'
 
 export const RenderCountDouble = () => {
   const constDoubleCount = useValue(doubleClicksState)
@@ -23,9 +23,7 @@ export const IncreaseButton2 = () => {
 
   return (
     <div>
-      <button onClick={() => setAtomValue((value) => value + 1)}>
-        increase
-      </button>
+      <button onClick={() => setAtomValue(value => value + 1)}>increase</button>
     </div>
   )
 }

--- a/mocks/atoms.ts
+++ b/mocks/atoms.ts
@@ -1,28 +1,28 @@
-import { atom } from "../"
+import { atom } from '../'
 
 export const clicksState = atom({
-  key: "clicks-count",
-  default: 0,
+  key: 'clicks-count',
+  default: 0
 })
 
 export const nameState = atom({
-  key: "user-name",
-  default: "",
+  key: 'user-name',
+  default: ''
 })
 
 export const doubleClicksState = atom({
-  key: "clicksFilter",
+  key: 'clicksFilter',
   default: 0,
   get({ get }) {
     const count = get(clicksState)
     return count * 2
-  },
+  }
 })
 
 export const tripleClicksState = atom({
-  key: "tripleCliksFilter",
+  key: 'tripleCliksFilter',
   get({ get }) {
     const double = get(doubleClicksState)
     return double * 3
-  },
+  }
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atomic-state",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Atomic State is a state management library for React",
   "main": "dist/index.js",
   "repository": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,44 +1,22 @@
-export { AtomicState } from "./server"
+export { AtomicState } from './server'
 
 export type {
   ActionType,
   ActionsObjectType,
   Atom,
-  /**
-   * @deprecated
-   */
-  Filter,
-  Selector,
-  FilterGet,
   PersistenceStoreType,
-  useAtomType,
-} from "./mod"
+  useAtomType
+} from './mod'
 
 export {
   atom,
   atomProvider,
-  /**
-   * @deprecated
-   */
-  filter,
-  selector,
-  /**
-   * @deprecated
-   */
-  filterProvider,
-  selectorProvider,
+  stateProvider,
   storage,
   takeSnapshot,
   useActions,
   useAtom,
-  useAtomActions,
-  useAtomDispatch,
-  useAtomValue,
   useDispatch,
-  /**
-   * @deprecated
-   */
-  useFilter,
   useStorage,
   useStorageItem,
   useValue,
@@ -46,20 +24,7 @@ export {
   createAtomicHook,
   createPersistence,
   setAtom,
-  getActions,
-} from "./mod"
+  getActions
+} from './mod'
 
-export {
-  getAtomValue,
-  getAtom,
-  /**
-   * @deprecated
-   */
-  getFilterValue,
-  /**
-   * @deprecated
-   */
-  getFilter,
-  getSelector,
-  getValue,
-} from "./store"
+export { getAtomValue, getAtom, getValue } from './store'

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -1,2 +1,2 @@
-"use client"
-export { AtomicState } from "../mod"
+'use client'
+export { AtomicState } from '../mod'

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,10 +1,9 @@
-import { Atom, Filter } from "./mod"
+import { Atom, Selector } from './mod'
 
 export const defaultAtomsValues: any = {}
 export const atomsInitializeObjects: any = {}
-export const filtersInitializeObjects: any = {}
+export const filtersInitializeObjects: any = atomsInitializeObjects
 export const defaultAtomsInAtomic: any = {}
-export const defaultFiltersInAtomic: any = {}
 export const usedKeys: any = {}
 export const defaultFiltersValues: any = {}
 export const atomsEffectsCleanupFunctons: any = {}
@@ -18,9 +17,14 @@ export function getAtomValue<R>(
   prefix?: string
 ): R {
   const $key = prefix
-    ? [prefix, ($atom as any)["atom-name"]].join("-")
-    : ($atom as any)["atom-name"]
+    ? [prefix, ($atom as any)['atom-name']].join('-')
+    : ($atom as any)['atom-name']
   const $atomValue = defaultAtomsValues[$key]
+
+  console.log({
+    defaultAtomsValues,
+    $key
+  })
   return $atomValue
 }
 
@@ -28,12 +32,12 @@ export function getAtomValue<R>(
  * Get the current value of a filter. You can pass a specific prefix as the second argument.
  */
 export function getFilterValue<R>(
-  $filter: (() => R | Promise<R>) | Filter<R | Promise<R>>,
+  $filter: (() => R | Promise<R>) | Selector<R | Promise<R>>,
   prefix?: string
 ): R {
   const $key = prefix
-    ? [prefix, ($filter as any)["filter-name"]].join("-")
-    : ($filter as any)["filter-name"]
+    ? [prefix, ($filter as any)['filter-name']].join('-')
+    : ($filter as any)['filter-name']
 
   const $filterValue = defaultFiltersValues[$key]
   return $filterValue
@@ -43,9 +47,12 @@ export const getAtom = getAtomValue
 export const getFilter = getFilterValue
 export const getSelector = getFilterValue
 
-export function getValue<R = any>(init: Atom<R> | Filter<R>, prefix?: string) {
-  const isFilter = (init as any)["init-object"].get
+export function getValue<R = any>(
+  init: Atom<R> | Selector<R>,
+  storeName: string | boolean = false
+) {
+  const isFilter = (init as any)['init-object'].get
   if (!isFilter) {
-    return getAtom(init, prefix)
-  } else return getFilter(init as Filter<R>, prefix)
+    return getAtom(init, storeName as string)
+  } else return getFilter(init as Selector<R>, storeName as string)
 }


### PR DESCRIPTION
- Enhances type naming
- Fixes `storeName` not working correctly
- Fixes extra `-` in atom name when creating a store with the `<AtomicState>` root
- Using `selector` to create selectors is now unnecesary (the atom function does that under the hood), while keeping all the necessary static typing