### PR TITLE
fix(atom initialize):

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atomic-state",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Atomic State is a state management library for React",
   "main": "dist/index.js",
   "repository": {

--- a/src/mod.tsx
+++ b/src/mod.tsx
@@ -350,7 +350,7 @@ export const AtomicState: React.FC<{
     }
   }
 
-  const createdAtoms = Object.values(atomsInitializeObjects) as any
+  const createdAtoms = Array.from(atomsInitializeObjects.values()) as any
 
   const thisId = useMemo(() => Math.random(), []).toString()
 
@@ -956,7 +956,7 @@ export function atom<R, ActionsArgs = any>(
 
     usedKeys.set(init.name, true)
 
-    if (!atomsInitializeObjects.get(init.name)) {
+    if (!atomsInitializeObjects.has(init.name)) {
       atomsInitializeObjects.set(init?.name, init)
     }
 


### PR DESCRIPTION
Fixes atoms not being initialized before render due to using Object.values instead of Map.values